### PR TITLE
Fix template placeholder parsing

### DIFF
--- a/html_template.html
+++ b/html_template.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta charset="UTF-8">
-<title>${title}</title>
+<title>%{title}</title>
 <script type="text/javascript">
   MathJax = {
     tex: {
@@ -25,9 +25,9 @@
 </style>
 </head>
 <body>
-<h1>${title}</h1>
-<h1>New papers on ${date}</h1>
+<h1>%{title}</h1>
+<h1>New papers on %{date}</h1>
 <hr>
-${content}
+%{content}
 </body>
 </html>

--- a/rssparser.py
+++ b/rssparser.py
@@ -200,8 +200,11 @@ def generate_html(all_entries_per_feed, html_file_path, search_description):
     file_exists = os.path.exists(html_file_path)
 
     if not file_exists:
+        class PercentTemplate(Template):
+            delimiter = '%'
+
         with open(HTML_TEMPLATE_PATH, 'r', encoding='utf-8') as tmpl:
-            template = Template(tmpl.read())
+            template = PercentTemplate(tmpl.read())
         rendered = template.substitute(
             title=html.escape(search_description),
             date=datetime.date.today(),


### PR DESCRIPTION
## Summary
- allow `$` tokens in MathJax template by switching to `%` delimiter
- update the HTML template to use `%{title}`, `%{date}`, and `%{content}`

## Testing
- `python -m py_compile rssparser.py`

------
https://chatgpt.com/codex/tasks/task_e_6842deeaebe483328b351dbbe612ad6c