### PR TITLE
Fix MAIN_DIR for cron execution

### DIFF
--- a/rssparser.py
+++ b/rssparser.py
@@ -18,7 +18,7 @@ logging.basicConfig(level=logging.INFO)
 
 # Constants
 TIME_DELTA = datetime.timedelta(days=182)  # Approximately 6 months
-MAIN_DIR = os.getcwd()
+MAIN_DIR = os.path.dirname(os.path.abspath(__file__))
 ASSETS_DIR = os.path.join(MAIN_DIR, 'assets')
 ARCHIVE_DIR = os.path.join(MAIN_DIR, 'archive')
 # MAIN_DIR = '/uu/nemes/cond-mat/'


### PR DESCRIPTION
## Summary
- use script location to build `MAIN_DIR` so cron finds assets database

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68443089ac1c8332bbe4294ad55565af