### PR TITLE
Improve LLM summarizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,12 @@ database and exit.
 
 ## LLM Summary
 
-When `OPENAI_API_KEY` is set, running `rssparser.py` will automatically
-generate an `llm_summary.html` file summarizing the most recent results.
-The summary is created using the OpenAI API and placed next to the parser
-scripts. If the key is missing or the `openai` package is unavailable the
-summary step is skipped.
+When `OPENAI_API_KEY` is set, running `rssparser.py` automatically
+creates an `llm_summary.html` file.  The script uses the OpenAI API to
+condense the latest `primary` results into a short (\<=400&nbsp;character)
+paragraph that highlights matches to the configured search terms.  The
+HTML then notes whether new `rg` papers were found and links to them if
+so, followed by a brief LLM summary of the entries for each search term
+defined in `search_terms.json`.  If the API key is missing or the
+`openai` package is unavailable the summary step is skipped.
 

--- a/llm_summary.py
+++ b/llm_summary.py
@@ -52,13 +52,16 @@ def call_llm(prompt: str, api_key: str) -> str:
     return resp.choices[0].message.content.strip()
 
 
-def summarize_entries(entries: List[Dict[str, str]], api_key: str) -> str:
+def summarize_entries(entries: List[Dict[str, str]], api_key: str, max_chars: int = 400) -> str:
     text = "\n".join(f"{e['title']}: {e.get('summary','')}" for e in entries)
     prompt = (
         "Summarize the following papers in under 400 characters, with emphasis "
         "on items most relevant to provided search terms:\n" + text
     )
-    return call_llm(prompt, api_key)
+    summary = call_llm(prompt, api_key)
+    if len(summary) > max_chars:
+        summary = summary[:max_chars].rsplit(' ', 1)[0] + '...'
+    return summary
 
 
 def generate_summary():


### PR DESCRIPTION
## Summary
- limit LLM summary to 400 characters by truncating if needed
- document how the summary file is generated and what it contains

## Testing
- `python -m py_compile rssparser.py llm_summary.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement feedparser)*

------
https://chatgpt.com/codex/tasks/task_e_68459275c51083328bd7067e24be1516