### PR TITLE
Add script to verify OpenAI API connectivity

### DIFF
--- a/test_openai_connection.py
+++ b/test_openai_connection.py
@@ -26,7 +26,7 @@ def main() -> None:
         print(model.id)
 
     response = client.chat.completions.create(
-        model="gpt-3.5-turbo",
+        model="gpt-4.1-nano",
         messages=[{"role": "user", "content": "Tell me a short joke."}],
         max_tokens=50,
     )


### PR DESCRIPTION
## Summary
- add `test_openai_connection.py` for requesting a chat completion

## Testing
- `pytest -q`
- `python test_openai_connection.py` *(fails: API connection error)*

------
https://chatgpt.com/codex/tasks/task_e_6845b2db3650833292dc2418f43e55e7