### PR TITLE
Add urllib-based OpenAI example

### DIFF
--- a/openai_cli.py
+++ b/openai_cli.py
@@ -1,0 +1,48 @@
+import json
+import urllib.request
+
+
+def load_api_key(path="openaikulcs.env"):
+    """Read the OpenAI API key from a file."""
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read().strip()
+
+
+def main():
+    api_key = load_api_key()
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    # List available models
+    req = urllib.request.Request(
+        "https://api.openai.com/v1/models",
+        headers=headers,
+    )
+    with urllib.request.urlopen(req) as response:
+        models_data = json.load(response)
+
+    for model in models_data.get("data", []):
+        print(model["id"])
+
+    # Chat completion
+    data = json.dumps({
+        "model": "gpt-4.1-nano",
+        "messages": [{"role": "user", "content": "Tell me a short joke."}],
+        "max_tokens": 50,
+    }).encode("utf-8")
+
+    chat_req = urllib.request.Request(
+        "https://api.openai.com/v1/chat/completions",
+        headers=headers,
+        data=data,
+    )
+    with urllib.request.urlopen(chat_req) as chat_response:
+        chat_data = json.load(chat_response)
+
+    print(chat_data["choices"][0]["message"]["content"])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a small script `openai_cli.py` that demonstrates accessing the OpenAI API
  using only `urllib.request`

## Testing
- `python -m py_compile openai_cli.py`
- `python openai_cli.py` *(fails: FileNotFoundError for `openaikulcs.env`)*

------
https://chatgpt.com/codex/tasks/task_e_6845ba7aca8c833298b8e8fb6cf8c7cb