### PR TITLE
Fix openai_cli env path

### DIFF
--- a/openai_cli.py
+++ b/openai_cli.py
@@ -1,9 +1,12 @@
 import json
+import os
 import urllib.request
 
 
 def load_api_key(path="openaikulcs.env"):
     """Read the OpenAI API key from a file."""
+    if not os.path.isabs(path):
+        path = os.path.join(os.path.dirname(__file__), path)
     with open(path, "r", encoding="utf-8") as f:
         return f.read().strip()
 


### PR DESCRIPTION
## Summary
- use os to make API key path relative to script location

## Testing
- `python -m py_compile openai_cli.py rssparser.py`


------
https://chatgpt.com/codex/tasks/task_e_6845bed9409c83329c36d5a66631ed11