### PR TITLE
Improve loading of OpenAI API keys

### DIFF
--- a/openai_cli.py
+++ b/openai_cli.py
@@ -4,11 +4,19 @@ import urllib.request
 
 
 def load_api_key(path="openaikulcs.env"):
-    """Read the OpenAI API key from a file."""
+    """Return the OpenAI API key from the environment or a file."""
+    env_key = os.getenv("OPENAI_API_KEY")
+    if env_key:
+        return env_key
+
     if not os.path.isabs(path):
         path = os.path.join(os.path.dirname(__file__), path)
+
     with open(path, "r", encoding="utf-8") as f:
-        return f.read().strip()
+        key = f.read().strip()
+        if "=" in key:
+            key = key.split("=", 1)[-1].strip()
+        return key
 
 
 def main():


### PR DESCRIPTION
## Summary
- support reading OPENAI_API_KEY from environment
- allow parsing `KEY=value` lines when reading API key file

## Testing
- `python -m py_compile openai_cli.py rssparser.py`

------
https://chatgpt.com/codex/tasks/task_e_6845c12808908332bbdb56b31ed7c570