### PR TITLE
Fix link formatting in summary output

### DIFF
--- a/llmsummary.py
+++ b/llmsummary.py
@@ -89,8 +89,29 @@ def summarize_primary(titles, search_terms, char_limit=600):
 
 def generate_html(primary_summary, rg_info, topic_summaries, output_path):
     today = datetime.date.today()
+    def extract_links(text: str):
+        """Return text without Markdown links and list of (title, url) tuples."""
+        link_pat = re.compile(r"\[([^\]]+)\]\((https?://[^\)]+)\)")
+        match = re.search(r"Top\s*\d+.*?:", text, re.IGNORECASE)
+        if match:
+            main = text[: match.start()].strip()
+            link_text = text[match.end() :]
+        else:
+            main = text
+            link_text = ""
+        links = link_pat.findall(link_text)
+        return main, links
+
+    primary_text, primary_links = extract_links(primary_summary)
+
+    def format_links(links):
+        if not links:
+            return ""
+        parts = [f'<a href="{url}">{html.escape(title)}</a>' for title, url in links]
+        return "<p>" + "<br>".join(parts) + "</p>"
+
     sections = [
-        f"<h2>Primary</h2><p>{html.escape(primary_summary)}</p>",
+        f"<h2>Primary</h2><p>{html.escape(primary_text)}</p>" + format_links(primary_links),
         f"<h2>RG</h2><p>{html.escape(rg_info)}</p>",
     ]
     for topic, summ in topic_summaries.items():


### PR DESCRIPTION
## Summary
- convert markdown style links in `llmsummary.py` to HTML
- place link list under the primary summary so they appear clickable

## Testing
- `python3 -m pip install -r requirements.txt`
- `python3 -m py_compile llmsummary.py rssparser.py openai_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_6845d22dfca88332a94c9cc23ab8055e