### PR TITLE
Add summary trigger and option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,6 @@ Current use case is FTP upload to a website, you can set this up for yourself. H
 The generated HTML files will be uploaded to the FTP server by default. Pass
 `--no-upload` when running the script to skip the FTP step, which can be useful
 for testing.  Pass `--clear-db` to remove all stored article IDs from the database and exit.
+By default the script runs `llmsummary.py` at the end to create a daily summary.
+Use the `--no-summary` option if you want to skip this step.
 

--- a/rssparser.py
+++ b/rssparser.py
@@ -12,6 +12,7 @@ import ftplib
 import json
 import sys
 import argparse
+import llmsummary
 
 # Setup logging
 logging.basicConfig(level=logging.INFO)
@@ -444,6 +445,12 @@ if __name__ == "__main__":
         dest="clear_db",
         help="remove all entries in the SQLite database and exit",
     )
+    parser.add_argument(
+        "--no-summary",
+        action="store_true",
+        dest="no_summary",
+        help="skip running the LLM summary step",
+    )
     args = parser.parse_args()
 
     if args.clear_db:
@@ -454,4 +461,7 @@ if __name__ == "__main__":
 
     main(upload=args.upload)
     conn.close()
+
+    if not args.no_summary:
+        llmsummary.main()
     


### PR DESCRIPTION
## Summary
- call llmsummary from `rssparser` by default
- add `--no-summary` CLI option to `rssparser`
- document automatic summary generation

## Testing
- `python -m py_compile rssparser.py llmsummary.py openai_cli.py`
- `python rssparser.py --no-upload --no-summary --clear-db`
- `python rssparser.py --help`

------
https://chatgpt.com/codex/tasks/task_e_6845d5c3d0388332ba5e77835e7e5b9c