### PR TITLE
Link parser output with summary function

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The generated HTML files will be uploaded to the FTP server by default. Pass
 for testing.  Pass `--clear-db` to remove all stored article IDs from the database and exit.
 By default the script runs `llmsummary.py` at the end to create a daily summary.
 The parser now passes the collected feed entries directly to `llmsummary.py` rather than
-having it parse the generated HTML files.  Use the `--no-summary` option if you want to skip
+having it parse the generated HTML files. Each entry includes its title and summary so the
+language model receives more context. Use the `--no-summary` option if you want to skip
 this step.
 

--- a/README.md
+++ b/README.md
@@ -38,5 +38,7 @@ The generated HTML files will be uploaded to the FTP server by default. Pass
 `--no-upload` when running the script to skip the FTP step, which can be useful
 for testing.  Pass `--clear-db` to remove all stored article IDs from the database and exit.
 By default the script runs `llmsummary.py` at the end to create a daily summary.
-Use the `--no-summary` option if you want to skip this step.
+The parser now passes the collected feed entries directly to `llmsummary.py` rather than
+having it parse the generated HTML files.  Use the `--no-summary` option if you want to skip
+this step.
 

--- a/llmsummary.py
+++ b/llmsummary.py
@@ -50,14 +50,15 @@ def extract_titles(file_path):
     return entries
 
 
-def extract_titles_from_entries(entries):
-    """Return list of (title, link) tuples from a list of RSS entries."""
-    titles = []
+def extract_entry_details(entries):
+    """Return list of (title, summary, link) tuples from RSS entries."""
+    details = []
     for entry in entries:
         title = html.unescape(entry.get('title', '')).strip()
+        summary = html.unescape(entry.get('summary', '')).strip()
         link = entry.get('link')
-        titles.append((title, link))
-    return titles
+        details.append((title, summary, link))
+    return details
 
 
 def chat_completion(prompt, max_tokens=200):
@@ -82,10 +83,18 @@ def chat_completion(prompt, max_tokens=200):
     return result['choices'][0]['message']['content']
 
 
-def summarize_titles(titles, prompt_prefix, char_limit=3000, search_context=None):
-    if not titles:
+def summarize_entries(entries, prompt_prefix, char_limit=3000, search_context=None):
+    if not entries:
         return 'No new papers.'
-    joined = '; '.join(t for t, _ in titles)
+    def to_text(item):
+        if len(item) == 3:
+            t, s, _ = item
+            return f"{t} - {s}"
+        else:
+            t, _ = item
+            return t
+
+    joined = '; '.join(to_text(e) for e in entries)
     context = f"Search terms: {search_context}\n" if search_context else ''
     prompt = (
         f"{prompt_prefix}\n"
@@ -96,11 +105,19 @@ def summarize_titles(titles, prompt_prefix, char_limit=3000, search_context=None
     return chat_completion(prompt, max_tokens=2000)
 
 
-def summarize_primary(titles, search_terms, char_limit=4000):
-    """Summarize primary titles with links and search terms."""
-    if not titles:
+def summarize_primary(entries, search_terms, char_limit=4000):
+    """Summarize primary entries with titles, links and summaries."""
+    if not entries:
         return 'No new papers.'
-    titles_links = '; '.join(f"{t} ({link})" for t, link in titles)
+    def to_text(item):
+        if len(item) == 3:
+            t, s, link = item
+            return f"{t} ({link}) - {s}"
+        else:
+            t, link = item
+            return f"{t} ({link})"
+
+    titles_links = '; '.join(to_text(e) for e in entries)
     prompt = (
         f"Search terms:\n{json.dumps(search_terms, indent=2)}\n"
         "Summarize the following papers with emphasis on those best matching the primary search terms. "
@@ -164,8 +181,8 @@ def main(entries_per_topic=None):
             stable_files[t] = f'{t}_filtered_articles.html'
 
     if entries_per_topic is None:
-        primary_titles = extract_titles(os.path.join(MAIN_DIR, stable_files['primary']))
-        rg_titles = extract_titles(os.path.join(MAIN_DIR, stable_files['rg']))
+        primary_entries = extract_titles(os.path.join(MAIN_DIR, stable_files['primary']))
+        rg_entries = extract_titles(os.path.join(MAIN_DIR, stable_files['rg']))
     else:
         def flatten(topic):
             entries = []
@@ -173,17 +190,17 @@ def main(entries_per_topic=None):
                 entries.extend(feed_entries)
             return entries
 
-        primary_titles = extract_titles_from_entries(flatten('primary'))
-        rg_titles = extract_titles_from_entries(flatten('rg'))
+        primary_entries = extract_entry_details(flatten('primary'))
+        rg_entries = extract_entry_details(flatten('rg'))
 
     primary_summary = summarize_primary(
-        primary_titles,
+        primary_entries,
         terms,
         char_limit=4000,
     )
 
-    if rg_titles:
-        rg_info = f"There are {len(rg_titles)} new RG papers. See {stable_files['rg']}"
+    if rg_entries:
+        rg_info = f"There are {len(rg_entries)} new RG papers. See {stable_files['rg']}"
     else:
         rg_info = "No new RG papers today."
 
@@ -192,11 +209,11 @@ def main(entries_per_topic=None):
         if t in ('primary', 'rg'):
             continue
         if entries_per_topic is None:
-            titles = extract_titles(os.path.join(MAIN_DIR, stable_files[t]))
+            entries = extract_titles(os.path.join(MAIN_DIR, stable_files[t]))
         else:
-            titles = extract_titles_from_entries(flatten(t))
-        topic_summaries[t] = summarize_titles(
-            titles,
+            entries = extract_entry_details(flatten(t))
+        topic_summaries[t] = summarize_entries(
+            entries,
             f"Summary of today's {t} papers:",
             char_limit=2000,
             search_context=terms.get(t)

--- a/rssparser.py
+++ b/rssparser.py
@@ -432,6 +432,8 @@ def main(upload: bool = True):
             logging.error("FTP upload failed: %s", e)
             sys.exit(1)
 
+    return all_new_entries
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Process RSS feeds")
@@ -461,11 +463,11 @@ if __name__ == "__main__":
         conn.close()
         sys.exit(0)
 
-    main(upload=args.upload)
+    new_entries = main(upload=args.upload)
     conn.close()
 
     if not args.no_summary:
-        llmsummary.main()
+        llmsummary.main(new_entries)
         if args.upload:
             if not FTP_USER or not FTP_PASS:
                 raise ValueError(


### PR DESCRIPTION
## Summary
- have `rssparser.main` return the new entry dictionary and forward it to `llmsummary.main`
- adjust `llmsummary` so it can consume dictionaries of entries instead of reading HTML files
- document the new behaviour in the README

## Testing
- `python -m py_compile rssparser.py llmsummary.py`
- `python rssparser.py --no-upload --no-summary`
- `python - <<'PY'
import llmsummary
llmsummary.main({'primary':{'feed':[]},'rg':{'feed':[]}})
print('done')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68498e390ffc8332bb7570d3bb6d61aa