### PR TITLE
Add daily rg summarization

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ Current use case is FTP upload to a website, you can set this up for yourself. H
    error if this file is missing.
 3. Place a `search_terms.json` file next to `rssparser.py` to
    override the default search regular expressions. The file may define any
-   number of topics as key/value pairs where the key is a name and the value is
-   a regular expression.  The special topic `rg` is updated in-place each run,
-   while all other topics (including `primary` and `perovskites`) generate daily
-   HTML files which are archived automatically.
+  number of topics as key/value pairs where the key is a name and the value is
+  a regular expression.  The special topic `rg` is updated in-place each run,
+  while all other topics (including `primary` and `perovskites`) generate daily
+  HTML files which are archived automatically.
+   Summaries for `rg` only include the new entries discovered on a given day.
 4. To add your own topics, edit `search_terms.json` and add a new key/value
    pair with the topic name as the key and a regular expression as the value.
    The parser will automatically generate an HTML summary for every topic it

--- a/llmsummary.py
+++ b/llmsummary.py
@@ -199,10 +199,12 @@ def main(entries_per_topic=None):
         char_limit=4000,
     )
 
-    if rg_entries:
-        rg_info = f"There are {len(rg_entries)} new RG papers. See {stable_files['rg']}"
-    else:
-        rg_info = "No new RG papers today."
+    rg_info = summarize_entries(
+        rg_entries,
+        "Summary of today's rg papers:",
+        char_limit=2000,
+        search_context=terms.get('rg'),
+    )
 
     topic_summaries = {}
     for t in topics:


### PR DESCRIPTION
## Summary
- summarize rg entries using only today's results
- document rg summarization behavior in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684997252d288332a887c23acb50753d