### PR TITLE
Add configurable LLM prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ for testing.  Pass `--clear-db` to remove all stored article IDs from the databa
 By default the script runs `llmsummary.py` at the end to create a daily summary.
 The parser now passes the collected feed entries directly to `llmsummary.py` rather than
 having it parse the generated HTML files. Each entry includes its title and summary so the
-language model receives more context. Use the `--no-summary` option if you want to skip
-this step.
+  language model receives more context. Use the `--no-summary` option if you want to skip
+  this step. Custom LLM instructions can be placed in an `llm_prompts.json` file
+  next to `llmsummary.py` where the keys correspond to topic names.
 

--- a/llm_prompts.json
+++ b/llm_prompts.json
@@ -1,0 +1,5 @@
+{
+  "primary": "Summarize the following papers with emphasis on those best matching the primary search terms. Place the 5 best matching the primary search terms into a list of links at the end of the summary.",
+  "rg": "Summary of today's rg papers:",
+  "perovskites": "Summary of today's perovskites papers:"
+}


### PR DESCRIPTION
## Summary
- allow llmsummary to load prompts from `llm_prompts.json`
- append search_terms.json to every prompt
- document custom prompt file in README

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_6849a23a77708332afda2eb03c2853a2