### PR TITLE
Include links in topic summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,11 @@ The parser now passes the collected feed entries directly to `llmsummary.py` rat
 having it parse the generated HTML files. Each entry includes its title and summary so the
   language model receives more context. Use the `--no-summary` option if you want to skip
   this step. Custom LLM instructions can be placed in an `llm_prompts.json` file
-  next to `llmsummary.py` where the keys correspond to topic names.
+next to `llmsummary.py` where the keys correspond to topic names.
+
+The `rg` topic and any additional topics now pass each paper's link to the
+language model, enabling summaries with numbered citation links like
+`[1](URL)`.
 
 Summaries now include numbered citation links like `[1](URL)` directly after each
 paper reference, making it easy to jump to the manuscript from the text.

--- a/llmsummary.py
+++ b/llmsummary.py
@@ -107,11 +107,11 @@ def summarize_entries(entries, prompt_prefix, char_limit=3000, search_context=No
         return 'No new papers.'
     def to_text(item):
         if len(item) == 3:
-            t, s, _ = item
-            return f"{t} - {s}"
+            t, s, link = item
+            return f"{t} ({link}) - {s}"
         else:
-            t, _ = item
-            return t
+            t, link = item
+            return f"{t} ({link})"
 
     joined = '; '.join(f"[{i+1}] {to_text(e)}" for i, e in enumerate(entries))
     context = f"Search terms: {search_context}\n" if search_context else ''


### PR DESCRIPTION
## Summary
- include link in `summarize_entries` so that RG and other topics cite links
- document that RG and custom topics pass links to the model

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'EOF'
import llmsummary
llmsummary.chat_completion = lambda prompt, max_tokens=2000: prompt
entries=[("Title A","Summary A","http://example.com/a"), ("Title B","Summary B","http://example.com/b")]
print(llmsummary.summarize_entries(entries, "PREFIX", char_limit=100))
EOF`
- `python - <<'EOF'
import llmsummary
llmsummary.chat_completion = lambda prompt, max_tokens=2000: prompt
entries=[("Title A","http://example.com/a"), ("Title B","http://example.com/b")]
print(llmsummary.summarize_entries(entries, "PREFIX", char_limit=100))
EOF`


------
https://chatgpt.com/codex/tasks/task_e_684ac14aa1888332b2af90385304eb19