### PR TITLE
Fix link parsing in markdown_to_html

### DIFF
--- a/llmsummary.py
+++ b/llmsummary.py
@@ -155,9 +155,12 @@ def summarize_primary(entries, search_terms, prompt_prefix, char_limit=4000):
 
 
 def markdown_to_html(text: str) -> str:
-    """Convert a small subset of Markdown to HTML using only the standard library."""
+    """Convert a small subset of Markdown to HTML using only the standard library.
+
+    The parser supports links with optional whitespace such as ``[1] (url)``.
+    """
     patterns = re.finditer(
-        r"\[([^\]]+)\]\((https?://[^)]+)\)|\*\*([^*]+)\*\*|\*([^*]+)\*",
+        r"\[([^\]]+)\]\s*\(\s*(https?://[^)]+)\s*\)|\*\*([^*]+)\*\*|\*([^*]+)\*",
         text,
     )
     pos = 0


### PR DESCRIPTION
## Summary
- update markdown regex to allow optional spaces around links
- document new behavior

## Testing
- `python -m compileall -q .`
- `python -m unittest discover`
- `pip install -r requirements.txt`
- `python - <<'EOF'
from llmsummary import markdown_to_html
print(markdown_to_html('[1] (https://example.com)'))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684ac165b89883328a38b3de8dfec1d1