### PR TITLE
Fix unnecessary f-strings in HTML generator

### DIFF
--- a/llmsummary.py
+++ b/llmsummary.py
@@ -181,8 +181,8 @@ def markdown_to_html(text: str) -> str:
 def generate_html(primary_summary, rg_info, topic_summaries, output_path):
     today = datetime.date.today()
     sections = [
-        f"<h2>Primary</h2>" + markdown_to_html(primary_summary),
-        f"<h2>RG</h2>" + markdown_to_html(rg_info),
+        "<h2>Primary</h2>" + markdown_to_html(primary_summary),
+        "<h2>RG</h2>" + markdown_to_html(rg_info),
     ]
     for topic, summ in topic_summaries.items():
         sections.append(f"<h2>{html.escape(topic)}</h2>" + markdown_to_html(summ))


### PR DESCRIPTION
## Summary
- remove unused f-string prefixes in `generate_html`
- run ruff to ensure clean linting

## Testing
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_684ac16fde488332aa7e04f2a87c1d5b