### PR TITLE
Update summary prompts for new numbering style

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,6 @@ The `rg` topic and any additional topics now pass each paper's link to the
 language model, enabling summaries with numbered citation links like
 `[1](URL)`.
 
-Summaries now include numbered citation links like `[1](URL)` directly after each
-paper reference, making it easy to jump to the manuscript from the text.
+Summaries now list each entry's main point on its own line and finish with the
+matching citation link, so you might see `[1](URL)` at the end of every line.
 

--- a/llmsummary.py
+++ b/llmsummary.py
@@ -231,7 +231,7 @@ def main(entries_per_topic=None):
     primary_prompt = prompts.get(
         'primary',
         'Summarize the following papers with emphasis on those best matching the primary search terms. '
-        'When referencing a paper, append a numbered citation such as [1](URL) directly after the relevant text.'
+        'Write one line per entry and end it with the numbered citation link, e.g. [1](URL).'
     )
     primary_summary = summarize_primary(
         primary_entries,
@@ -244,7 +244,7 @@ def main(entries_per_topic=None):
     # in case of no prompt, use a generic one in the second argument of the get() method
     rg_prompt = prompts.get(
         'rg',
-        "Summary of today's rg papers with numbered citation links after each mention:"
+        "Write one line per entry summarizing today's rg papers and finish each line with the numbered citation link, for example [1](URL)."
     )
     rg_info = summarize_entries(
         rg_entries,
@@ -265,7 +265,7 @@ def main(entries_per_topic=None):
         # Fall back to a generic instruction if no prompt is defined for the topic
         topic_prompt = prompts.get(
             t,
-            f"Summary of today's {t} papers with numbered citation links after each mention:"
+            f"Write one line per entry summarizing today's {t} papers and finish each line with the numbered citation link, e.g. [1](URL)."
         )
         topic_summaries[t] = summarize_entries(
             entries,


### PR DESCRIPTION
## Summary
- describe new numbering style in README
- adjust default `primary_prompt`, `rg_prompt` and generic topic prompt for the line-per-entry output

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_684acf31032083329443d0eab2cb653c