### PR TITLE
Add purge by days option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Current use case is FTP upload to a website, you can set this up for yourself. H
 The generated HTML files will be uploaded to the FTP server by default. Pass
 `--no-upload` when running the script to skip the FTP step, which can be useful
 for testing.  Pass `--clear-db` to remove all stored article IDs from the database and exit.
+Use `--purge-days X` to remove entries older than `X` days from the database and exit.
 By default the script runs `llmsummary.py` at the end to create a daily summary.
 The parser now passes the collected feed entries directly to `llmsummary.py` rather than
 having it parse the generated HTML files. Each entry includes its title and summary so the

--- a/rssparser.py
+++ b/rssparser.py
@@ -137,6 +137,15 @@ def clear_database():
     cursor.execute("DELETE FROM seen_entries")
     conn.commit()
 
+def purge_database(days: int):
+    """Remove entries older than the specified number of days from the database."""
+    cutoff = (datetime.datetime.now() - datetime.timedelta(days=days)).isoformat()
+    cursor.execute(
+        "DELETE FROM seen_entries WHERE timestamp < ?",
+        (cutoff,),
+    )
+    conn.commit()
+
 def matches_search_terms(entry, search_pattern):
     """Check if the entry matches the given search pattern."""
     fields_to_search = []
@@ -422,6 +431,13 @@ if __name__ == "__main__":
         help="remove all entries in the SQLite database and exit",
     )
     parser.add_argument(
+        "--purge-days",
+        type=int,
+        metavar="DAYS",
+        dest="purge_days",
+        help="remove database entries older than DAYS days and exit",
+    )
+    parser.add_argument(
         "--no-summary",
         action="store_true",
         dest="no_summary",
@@ -432,6 +448,12 @@ if __name__ == "__main__":
     if args.clear_db:
         clear_database()
         print("All entries removed from the database.")
+        conn.close()
+        sys.exit(0)
+
+    if args.purge_days is not None:
+        purge_database(args.purge_days)
+        print(f"Entries older than {args.purge_days} days removed from the database.")
         conn.close()
         sys.exit(0)
 


### PR DESCRIPTION
## Summary
- allow purging old entries from the database via `--purge-days`
- document the new option in the README

## Testing
- `python -m py_compile rssparser.py llmsummary.py`
- `python rssparser.py --help | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_684ad8e284f88332bf2eb0dc55b87ce3