### PR TITLE
Add GitHub Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,42 @@
+name: Build and Deploy
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - run: python rssparser.py --no-upload
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      - name: Prepare site
+        run: |
+          mkdir site
+          cp -r archive site/ || true
+          cp *.html site/ || true
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ Summaries now list each entry's main point as a bullet numbered `1)`, `2)`,
 etc. and append the matching citation link at the end, so you might see
 `[1](URL)` at the end of every bullet.
 
+## GitHub Actions and Pages
+
+The repository includes a workflow (`.github/workflows/pages.yml`) that runs the
+parser on a daily schedule and publishes the generated HTML files to GitHub
+Pages.  Set an `OPENAI_API_KEY` secret in your repository so the summarization
+step can contact the API.  If you do not wish to use the language model, add
+`--no-summary` to the workflow command.
+
+Enable GitHub Pages in the repository settings and choose **GitHub Actions** as
+the source.  After the first successful run your pages will be available at the
+URL shown in the workflow output.
+
 ## Misc
 - Seen article IDs are tracked in an SQLite database stored under `assets/seen_entries.db`.
 - Focus of future development, see wiki.


### PR DESCRIPTION
## Summary
- add a workflow that runs the parser daily and publishes to GitHub Pages
- document how to enable GitHub Actions/Pages

## Testing
- `python -m py_compile rssparser.py llmsummary.py`

------
https://chatgpt.com/codex/tasks/task_e_684d37a472888332a1b4f0fab9dba8a3