### PR TITLE
Update workflow schedule to run at 6 AM UTC

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,7 +3,8 @@ name: Build and Deploy
 on:
   workflow_dispatch:
   schedule:
-    - cron: '18 13 * * *'
+    # Run every day at 6 AM UTC
+    - cron: '0 6 * * *'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- run the GitHub Pages workflow every day at 6 AM UTC

## Testing
- `python rssparser.py --help`
- `python llmsummary.py --help` *(prints nothing)*

------
https://chatgpt.com/codex/tasks/task_e_684d6319030083328ee9561a44edb6e3