### PR TITLE
Add persistent entry history

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ Seen article IDs and titles are tracked in an SQLite database (`assets/seen_entr
 - IDs are generated via SHA‑1 hash from entry `id`, URL (cleaned of query parameters), or a combination of title and publication date.
 - Duplicate detection uses article titles, skipping identical entries even if links change.
 
+Metadata for all new matching entries is stored in a separate SQLite database (`assets/matched_entries_history.db`).
+Each row stores the feed name, topic, entry ID, timestamp and the full entry metadata as JSON for later queries.
+The history database is never automatically purged, so it accumulates all matched entries across runs.
+
 ## Future Development
 
 - Planned enhancements and more details available in the repository wiki.


### PR DESCRIPTION
## Summary
- keep `matched_entries_history.db` intact when clearing or purging databases
- document that the history DB is never automatically purged

## Testing
- `python -m py_compile rssparser.py`


------
https://chatgpt.com/codex/tasks/task_e_686792e33b88833299cd01036ca19025