### PR TITLE
Add retry on rate limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Set these variables (e.g., in your crontab):
 - `FTP_USER`: FTP username
 - `FTP_PASS`: FTP password
 - `OPENAI_API_KEY`: OpenAI API key for summarization (optional; see below)
+- `OPENAI_REQUEST_DELAY`: Delay in seconds before retrying after a 429 error (default: 1 second)
 
 Alternatively, store your OpenAI API key in a file named `openaikulcs.env` next to `llmsummary.py`.
 


### PR DESCRIPTION
## Summary
- only wait before retrying when OpenAI returns a rate limit error
- document new retry behavior of `OPENAI_REQUEST_DELAY`
- default delay is now 1 second

## Testing
- `python -m py_compile llmsummary.py rssparser.py`


------
https://chatgpt.com/codex/tasks/task_e_686ad4d645cc833294aac1f894d5e136