### PR TITLE
Use HTML callout template for LLM summaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 archive/
 *.html
 !html_template.html
+!llmsummary_template.html
 
 *.db
 *.ipynb

--- a/llmsummary_template.html
+++ b/llmsummary_template.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>%{title}</title>
+<style>
+body { font-family: Arial, sans-serif; margin: 20px; }
+.callout { border-left: 4px solid #3b82f6; padding: 10px; margin: 20px 0; background-color: #f1f5fe; }
+.callout-title { font-weight: bold; margin-bottom: 5px; }
+.callout-content { margin-left: 10px; }
+</style>
+</head>
+<body>
+<h1>%{title}</h1>
+%{entries}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `llmsummary_template.html` with callout styles for standardized summaries
- update `llmsummary.py` to fill template and wrap each section in a callout box
- track `llmsummary_template.html` via `.gitignore`

## Testing
- `python -m py_compile llmsummary.py`
- `python llmsummary.py`


------
https://chatgpt.com/codex/tasks/task_e_688fa6f118808332bdad6c9c305421f0