### PR TITLE
Add CLI viewer for SQLite database

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ Seen article IDs and titles are tracked in an SQLite database (`assets/seen_entr
 - IDs are generated via SHA‑1 hash from entry `id`, URL (cleaned of query parameters), or a combination of title and publication date.
 - Duplicate detection uses article titles, skipping identical entries even if links change.
 
+You can inspect recent records directly from the command line:
+
+```bash
+python view_db.py --limit 20
+```
+
+This prints the latest rows from `assets/seen_entries.db` in a simple table.
+
 Metadata for all new matching entries is stored in a separate SQLite database (`assets/matched_entries_history.db`).
 Each row stores the feed name, topic, entry ID, timestamp and the full entry metadata as JSON for later queries.
 The history database is never automatically purged, so it accumulates all matched entries across runs.

--- a/view_db.py
+++ b/view_db.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Simple CLI viewer for the seen_entries SQLite database."""
+
+import argparse
+import os
+import sqlite3
+from textwrap import shorten
+
+# Paths relative to this file
+MAIN_DIR = os.path.dirname(os.path.abspath(__file__))
+ASSETS_DIR = os.path.join(MAIN_DIR, "assets")
+DB_PATH = os.path.join(ASSETS_DIR, "seen_entries.db")
+
+
+def format_rows(rows):
+    """Return formatted table rows for printing."""
+    headers = ["feed_name", "search_type", "entry_id", "timestamp", "title"]
+    table = []
+    for row in rows:
+        table.append(
+            [
+                row["feed_name"],
+                row["search_type"],
+                row["entry_id"],
+                row["timestamp"],
+                shorten(row["title"], width=60, placeholder="…"),
+            ]
+        )
+    widths = [len(h) for h in headers]
+    for r in table:
+        for i, cell in enumerate(r):
+            widths[i] = min(max(widths[i], len(str(cell))), 60)
+    lines = []
+    lines.append(" | ".join(h.ljust(widths[i]) for i, h in enumerate(headers)))
+    lines.append("-+-".join("-" * w for w in widths))
+    for r in table:
+        lines.append(" | ".join(str(cell).ljust(widths[i]) for i, cell in enumerate(r)))
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Display contents of seen_entries.db")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="Number of rows to display (default: 50)",
+    )
+    args = parser.parse_args()
+
+    if not os.path.exists(DB_PATH):
+        print(f"Database not found at {DB_PATH}")
+        return
+
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT feed_name, search_type, entry_id,
+               datetime(timestamp, 'unixepoch') AS timestamp, title
+        FROM seen_entries
+        ORDER BY timestamp DESC
+        LIMIT ?
+        """,
+        (args.limit,),
+    )
+    rows = cur.fetchall()
+    if not rows:
+        print("No entries found.")
+        return
+
+    print(format_rows(rows))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `view_db.py` script to display rows from `assets/seen_entries.db` in a table
- document database inspection script in README

## Testing
- `python rssparser.py --purge-days 1`
- `python rssparser.py --no-upload`


------
https://chatgpt.com/codex/tasks/task_e_689dda8f1a808332bb800efff9c2e261