### PR TITLE
Fix API key resolution fallback for summarize command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,8 @@ assets/paperqa_archive/*
 models/*
 assets/secrets/*
 config/secrets/*
+!config/secrets/README.md
+!config/secrets/email_password.env
+!config/secrets/mailing_lists.yaml
+!config/secrets/openaikulcs.env
 rg_papers_statistics/*

--- a/cli/main.py
+++ b/cli/main.py
@@ -21,6 +21,7 @@ from commands import abstracts as abstracts_cmd
 from commands import summarize as summarize_cmd
 from commands import pqa_summary as pqa_cmd
 from commands import email_list as email_cmd
+from core.config import DEFAULT_CONFIG_PATH
 from core.paths import get_data_dir
 
 # Setup logging
@@ -31,7 +32,12 @@ logging.basicConfig(
 
 
 @click.group()
-@click.option('--config', default='config/config.yaml', help='Path to config file')
+@click.option(
+    '--config',
+    default=str(DEFAULT_CONFIG_PATH),
+    show_default=True,
+    help='Path to config file (default: ~/.paper_firehose/config.yaml)',
+)
 @click.option('--verbose', '-v', is_flag=True, help='Enable verbose logging')
 @click.pass_context
 def cli(ctx, config, verbose):

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -7,6 +7,8 @@ database:
 llm:
   model: "gpt-5-mini"
   api_key_env: "OPENAI_API_KEY"
+  # Optional: override the default key location (~/.paper_firehose/secrets/openaikulcs.env)
+  # api_key_file: "secrets/openaikulcs.env"
   # Fallback model if the primary is unavailable/unsupported
   model_fallback: "gpt-5-nano"
   # Slower by default to be polite to API
@@ -209,7 +211,7 @@ defaults:
 
 # Email delivery (Mailman list)
 email:
-  recipients_file: "config/secrets/mailing_lists.yaml"
+  recipients_file: "secrets/mailing_lists.yaml"
   # Optional subject prefix
   subject_prefix: "paper firehose"
   # Sender address; defaults to smtp.username if omitted
@@ -219,4 +221,4 @@ email:
     port: 465
     username: "_mainaccount@nemeslab.com"
     # Prefer file-based secret storage. Put the password in this file (gitignored by you).
-    password_file: "config/secrets/email_password.env"
+    password_file: "secrets/email_password.env"

--- a/config/secrets/README.md
+++ b/config/secrets/README.md
@@ -1,0 +1,12 @@
+# Secrets directory
+
+This folder is copied to `~/.paper_firehose/secrets` on first run.
+
+Place sensitive configuration files here, such as:
+
+- `email_password.env`: contains the SMTP password used by the email sender
+- `mailing_lists.yaml`: optional per-recipient routing rules for the email command
+- `openaikulcs.env`: placeholder for the OpenAI API key used by LLM summarization utilities
+
+Files placed here are not tracked by git when copied to your home directory. Be
+sure to tighten file permissions manually if needed.

--- a/config/secrets/email_password.env
+++ b/config/secrets/email_password.env
@@ -1,0 +1,1 @@
+# Replace this line with your SMTP password (do not commit the filled-in file).

--- a/config/secrets/mailing_lists.yaml
+++ b/config/secrets/mailing_lists.yaml
@@ -1,0 +1,11 @@
+# Example recipients configuration for `paper-firehose email`.
+# Update the addresses and topic lists before enabling.
+recipients:
+  - to: "researcher@example.com"
+    topics: ["example"]
+    mode: "auto"
+    limit: 5
+  - to: "team@example.com"
+    topics: ["example"]
+    mode: "ranked"
+    min_rank_score: 0.5

--- a/config/secrets/openaikulcs.env
+++ b/config/secrets/openaikulcs.env
@@ -1,0 +1,4 @@
+# Placeholder API key file copied to ~/.paper_firehose/secrets.
+# Replace the contents of this file with your OpenAI API key, e.g.
+# OPENAI_API_KEY=sk-...
+# or just the raw key string.

--- a/paper_firehose/__init__.py
+++ b/paper_firehose/__init__.py
@@ -16,7 +16,7 @@ from commands import abstracts as abstracts_cmd  # type: ignore
 from commands import summarize as summarize_cmd  # type: ignore
 from commands import pqa_summary as pqa_summary_cmd  # type: ignore
 from commands import email_list as email_cmd  # type: ignore
-from core.config import ConfigManager  # type: ignore
+from core.config import ConfigManager, DEFAULT_CONFIG_PATH  # type: ignore
 from core.database import DatabaseManager  # type: ignore
 from processors.html_generator import HTMLGenerator  # type: ignore
 
@@ -25,7 +25,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_CONFIG = os.path.join(_REPO_ROOT, 'config', 'config.yaml')
+_DEFAULT_CONFIG = str(DEFAULT_CONFIG_PATH)
 
 __all__ = [
     'filter',

--- a/src/commands/abstracts.py
+++ b/src/commands/abstracts.py
@@ -485,7 +485,7 @@ def run(config_path: str, topic: Optional[str] = None, *, mailto: Optional[str] 
     """Fetch and write abstracts into papers.db for ranked entries.
 
     Args:
-        config_path: Path to config/config.yaml
+        config_path: Path to the main configuration file (defaults to ~/.paper_firehose/config.yaml)
         topic: Optional single topic; otherwise process all topics
         mailto: Contact email for Crossref User-Agent
         max_per_topic: Optional cap on number of fetches per topic

--- a/src/commands/summarize.py
+++ b/src/commands/summarize.py
@@ -19,12 +19,13 @@ from __future__ import annotations
 
 import os
 import time
+from pathlib import Path
 from typing import Optional, Dict, Any, List
 import logging
 import requests
 from openai import OpenAI
 
-from core.config import ConfigManager
+from core.config import ConfigManager, DEFAULT_CONFIG_DIR
 from core.database import DatabaseManager
 
 logger = logging.getLogger(__name__)
@@ -52,20 +53,47 @@ def _load_key_from_file(path: str) -> Optional[str]:
     return None
 
 
-def _resolve_api_key(config: Dict[str, Any]) -> str:
-    """Prefer key from repo-root openaikulcs.env, else env OPENAI_API_KEY."""
-    # Try CWD (repo root typical) first
-    key = _load_key_from_file('openaikulcs.env')
-    if not key:
-        # Try computing path relative to this file two levels up (src/commands -> repo root)
-        here = os.path.dirname(__file__)
-        repo_root_guess = os.path.abspath(os.path.join(here, '..', '..'))
-        key = _load_key_from_file(os.path.join(repo_root_guess, 'openaikulcs.env'))
-    if not key:
-        key = os.environ.get('OPENAI_API_KEY')
-    if not key:
-        raise RuntimeError("Missing OpenAI API key in openaikulcs.env or environment variable OPENAI_API_KEY")
-    return key
+def _resolve_api_key(config: Dict[str, Any], config_base_dir: Optional[str]) -> str:
+    """Resolve the OpenAI API key from the config directory, repo root, or environment."""
+
+    llm_cfg = (config.get('llm') or {})
+    env_var = llm_cfg.get('api_key_env') or 'OPENAI_API_KEY'
+    candidate_files: List[Path] = []
+    base_dir = Path(config_base_dir) if config_base_dir else Path(DEFAULT_CONFIG_DIR)
+
+    # Configurable key file path (optional)
+    key_file_cfg = (llm_cfg.get('api_key_file') or '').strip()
+    if key_file_cfg:
+        key_path = Path(key_file_cfg)
+        if key_path.is_absolute():
+            candidate_files.append(key_path)
+        else:
+            candidate_files.append(base_dir / key_path)
+            candidate_files.append(Path.cwd() / key_path)
+
+    # Default secrets location under the managed config directory
+    candidate_files.append(base_dir / 'secrets' / 'openaikulcs.env')
+    candidate_files.append(base_dir / 'openaikulcs.env')
+
+    # Legacy repo-root fallbacks for backwards compatibility
+    candidate_files.append(Path('openaikulcs.env'))
+    here = Path(__file__).resolve().parent
+    repo_root_guess = here.parent.parent
+    candidate_files.append(repo_root_guess / 'openaikulcs.env')
+
+    for path in candidate_files:
+        key = _load_key_from_file(str(path))
+        if key:
+            return key
+
+    key = os.environ.get(env_var)
+    if key:
+        return key
+
+    raise RuntimeError(
+        "Missing OpenAI API key. Set %s or place the key in %s"
+        % (env_var, base_dir / 'secrets' / 'openaikulcs.env')
+    )
 
 
 def _resolve_model(config: Dict[str, Any]) -> str:
@@ -263,7 +291,7 @@ def run(config_path: str, topic: Optional[str] = None, *, rps: Optional[float] =
     db = DatabaseManager(config)
 
     topics: List[str] = [topic] if topic else cfg_mgr.get_available_topics()
-    api_key = _resolve_api_key(config)
+    api_key = _resolve_api_key(config, cfg_mgr.base_dir)
     model = _resolve_model(config)
     model_fallback = (config.get('llm') or {}).get('model_fallback') or 'gpt-4o-mini'
     defaults = (config.get('defaults') or {})

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -1,24 +1,109 @@
-"""
-Configuration management for YAML-based config files.
-"""
+"""Configuration management for YAML-based config files."""
 
-import yaml
 import os
-from typing import Dict, Any, List
 import logging
 import re
+import shutil
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_CONFIG_DIR = Path.home() / ".paper_firehose"
+DEFAULT_CONFIG_PATH = DEFAULT_CONFIG_DIR / "config.yaml"
+_TEMPLATE_DIR = Path(__file__).resolve().parents[2] / "config"
+_TEMPLATE_CONFIG = _TEMPLATE_DIR / "config.yaml"
+_TEMPLATE_TOPICS_DIR = _TEMPLATE_DIR / "topics"
+_TEMPLATE_SECRETS_DIR = _TEMPLATE_DIR / "secrets"
+
+_DEFAULT_CONFIG_TEMPLATE = """# Auto-generated default configuration for paper-firehose
+database:
+  path: "papers.db"
+  all_feeds_path: "all_feed_entries.db"
+  history_path: "matched_entries_history.db"
+
+llm:
+  model: "gpt-5-mini"
+  api_key_env: "OPENAI_API_KEY"
+  model_fallback: "gpt-5-nano"
+  rps: 0.5
+  max_retries: 3
+
+paperqa:
+  download_rank_threshold: 0.35
+  rps: 0.3
+  max_retries: 3
+  prompt: >
+    Provide a concise summary of the paper in JSON with keys "summary" and "methods".
+
+feeds:
+  cond-mat:
+    name: "arXiv cond-mat"
+    url: "https://rss.arxiv.org/rss/cond-mat"
+    enabled: true
+
+priority_journals: []
+
+defaults:
+  time_window_days: 365
+  top_n_per_topic: 10
+  rank_threshold: 0.3
+  ranking_negative_penalty: 0.25
+"""
+
+_DEFAULT_TOPIC_TEMPLATE = """name: "example"
+description: "Auto-generated starter topic. Update the regex and feeds for your workflow."
+
+feeds:
+  - "cond-mat"
+
+filter:
+  pattern: "graphene"
+  fields: ["title", "summary"]
+
+ranking:
+  query: >
+    graphene
+    condensed matter
+"""
+
+
+def _write_template(path: Path, content: str) -> None:
+    path.write_text(content.strip() + "\n", encoding="utf-8")
+
+
+def _copy_tree(src: Path, dest: Path) -> bool:
+    """Copy files from *src* to *dest* without overwriting existing files."""
+
+    if not src.exists():
+        return False
+
+    created = False
+    for item in src.iterdir():
+        target = dest / item.name
+        if item.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+            if _copy_tree(item, target):
+                created = True
+        else:
+            if not target.exists():
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copyfile(item, target)
+                created = True
+    return created
 
 
 class ConfigManager:
     """Manages loading and validation of YAML configuration files."""
-    
-    def __init__(self, config_path: str = "config/config.yaml"):
-        self.config_path = config_path
-        self.base_dir = os.path.dirname(config_path)
+
+    def __init__(self, config_path: Optional[str] = None):
+        self.config_path = os.path.abspath(str(config_path or DEFAULT_CONFIG_PATH))
+        self.base_dir = os.path.dirname(self.config_path)
         self._config = None
         self._topics = {}
+        self._ensure_default_config()
     
     def load_config(self) -> Dict[str, Any]:
         """Load the main configuration file."""
@@ -46,6 +131,61 @@ class ConfigManager:
                 raise
         
         return self._topics[topic_name]
+
+    def _ensure_default_config(self) -> None:
+        """Create default configuration files if they are missing."""
+
+        config_file = Path(self.config_path)
+        config_file.parent.mkdir(parents=True, exist_ok=True)
+
+        if not config_file.exists():
+            if _TEMPLATE_CONFIG.exists():
+                try:
+                    shutil.copyfile(_TEMPLATE_CONFIG, config_file)
+                    logger.info("Created default config.yaml at %s", config_file)
+                except Exception as exc:
+                    logger.warning("Failed to copy template config: %s", exc)
+                    _write_template(config_file, _DEFAULT_CONFIG_TEMPLATE)
+            else:
+                _write_template(config_file, _DEFAULT_CONFIG_TEMPLATE)
+                logger.info("Created fallback default config.yaml at %s", config_file)
+
+        topics_dir = Path(self.base_dir) / "topics"
+        topics_dir.mkdir(parents=True, exist_ok=True)
+        secrets_dir = Path(self.base_dir) / "secrets"
+        secrets_dir.mkdir(parents=True, exist_ok=True)
+
+        created_topic = False
+        try:
+            if _copy_tree(_TEMPLATE_TOPICS_DIR, topics_dir):
+                created_topic = True
+        except Exception as exc:
+            logger.warning("Failed to copy topics template tree: %s", exc)
+
+        try:
+            _copy_tree(_TEMPLATE_SECRETS_DIR, secrets_dir)
+        except Exception as exc:
+            logger.warning("Failed to copy secrets template tree: %s", exc)
+
+        if not any(topics_dir.glob("*.yml")) and not any(topics_dir.glob("*.yaml")):
+            default_topic_path = topics_dir / "example.yaml"
+            _write_template(default_topic_path, _DEFAULT_TOPIC_TEMPLATE)
+            created_topic = True
+            logger.info("Created fallback default topic config at %s", default_topic_path)
+
+        if _TEMPLATE_DIR.exists():
+            for item in _TEMPLATE_DIR.iterdir():
+                if not item.is_dir() or item.name in {"topics", "secrets"}:
+                    continue
+                dest_dir = Path(self.base_dir) / item.name
+                dest_dir.mkdir(parents=True, exist_ok=True)
+                try:
+                    _copy_tree(item, dest_dir)
+                except Exception as exc:
+                    logger.warning("Failed to copy template directory %s: %s", item, exc)
+
+        if created_topic:
+            self._topics.clear()
     
     def get_available_topics(self) -> List[str]:
         """Get list of available topic configuration files."""
@@ -173,3 +313,10 @@ class ConfigManager:
         except Exception as e:
             logger.error(f"Configuration validation failed: {e}")
             return False
+
+
+__all__ = [
+    "ConfigManager",
+    "DEFAULT_CONFIG_PATH",
+    "DEFAULT_CONFIG_DIR",
+]

--- a/src/processors/emailer.py
+++ b/src/processors/emailer.py
@@ -2,7 +2,7 @@
 Email rendering and sending utilities for Paper Firehose.
 
 Generates a simple, email-friendly HTML digest from papers.db and sends it via
-SMTP (SSL) based on configuration in config/config.yaml under `email`.
+SMTP (SSL) based on configuration in ~/.paper_firehose/config.yaml under `email`.
 
 Uses only the Python standard library.
 """
@@ -17,6 +17,7 @@ import smtplib
 import ssl
 from email.message import EmailMessage
 from html.parser import HTMLParser
+from pathlib import Path
 
 
 def _fmt_score_badge(score: Optional[float]) -> str:
@@ -372,20 +373,23 @@ class EmailRenderer:
 class SMTPSender:
     """Send emails via SMTP (SSL) using settings under config['email']['smtp']."""
 
-    def __init__(self, smtp_cfg: Dict[str, Any]) -> None:
+    def __init__(self, smtp_cfg: Dict[str, Any], config_dir: Optional[str] = None) -> None:
         self.host = str(smtp_cfg.get('host') or '')
         self.port = int(smtp_cfg.get('port') or 465)
         self.username = str(smtp_cfg.get('username') or '')
         self.password = str(smtp_cfg.get('password') or '')  # discouraged; prefer file
         self.password_file = smtp_cfg.get('password_file')
+        self._config_dir = Path(config_dir).expanduser().resolve() if config_dir else None
 
     def _load_password(self) -> str:
         if self.password:
             return self.password
         if self.password_file:
-            path = str(self.password_file)
-            if os.path.exists(path):
-                with open(path, 'r', encoding='utf-8') as f:
+            candidate = Path(str(self.password_file)).expanduser()
+            if not candidate.is_absolute() and self._config_dir:
+                candidate = (self._config_dir / candidate).resolve()
+            if os.path.exists(candidate):
+                with open(candidate, 'r', encoding='utf-8') as f:
                     return f.read().strip()
         # Last resort: env var based on username
         env_name = 'SMTP_PASSWORD'

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,0 +1,41 @@
+"""Tests for configuration management defaults."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+# Ensure the repository's src/ directory is importable without installation.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = REPO_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+from core.config import ConfigManager  # noqa: E402
+
+
+def test_config_manager_creates_defaults(tmp_path):
+    """When pointed at an empty directory, default config and topic files are created."""
+
+    config_path = tmp_path / "config.yaml"
+    assert not config_path.exists()
+
+    cfg = ConfigManager(str(config_path))
+
+    assert config_path.exists(), "config.yaml should be created on first run"
+
+    topics_dir = tmp_path / "topics"
+    assert topics_dir.is_dir(), "topics directory should be created"
+
+    topic_files = list(topics_dir.glob("*.yml")) + list(topics_dir.glob("*.yaml"))
+    assert topic_files, "at least one topic YAML should be bootstrapped"
+
+    secrets_dir = tmp_path / "secrets"
+    assert secrets_dir.is_dir(), "secrets directory should be created for credential storage"
+    assert (secrets_dir / "email_password.env").exists(), "default SMTP password placeholder should be copied"
+    assert (secrets_dir / "mailing_lists.yaml").exists(), "sample recipients file should be copied"
+    assert (secrets_dir / "openaikulcs.env").exists(), "OpenAI API key placeholder should be copied"
+
+    # Ensure the manager can load the generated configuration without errors
+    data = cfg.load_config()
+    assert isinstance(data, dict)

--- a/tests/test_summarize_api_key.py
+++ b/tests/test_summarize_api_key.py
@@ -1,0 +1,34 @@
+"""Tests for API key resolution helpers used by summarize command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+
+# Ensure the repository's src/ directory is importable without installation.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = REPO_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+import commands.summarize as summarize  # noqa: E402
+
+
+def test_resolve_api_key_prefers_default_config_dir_when_base_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Relative api_key_file paths should resolve against the managed config directory."""
+
+    secrets_dir = tmp_path / "secrets"
+    secrets_dir.mkdir()
+    key_path = secrets_dir / "openaikulcs.env"
+    key_path.write_text("sk-test-123\n", encoding="utf-8")
+
+    monkeypatch.setattr(summarize, "DEFAULT_CONFIG_DIR", tmp_path)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    config = {"llm": {"api_key_file": "secrets/openaikulcs.env"}}
+
+    key = summarize._resolve_api_key(config, config_base_dir=None)
+
+    assert key == "sk-test-123"


### PR DESCRIPTION
## Summary
- ensure summarize API key resolution treats relative key file paths as relative to the managed config directory even when the base directory is unavailable
- normalize key lookup probing to use pathlib paths and default to the managed secrets directory
- add regression coverage for resolving keys when only the default config directory is present

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e233e6b91c8332ae20768a3e91ec18